### PR TITLE
Motor B fix 2

### DIFF
--- a/pipelines/ceus/tasks/project_loadshapes.py
+++ b/pipelines/ceus/tasks/project_loadshapes.py
@@ -82,7 +82,7 @@ class ProjectLoadshapes(t.Task):
                 base_loadshapes = self.loadshapes.loc[(self.loadshapes['fcz'] == base) & (self.loadshapes['buildingtype'] == buildingtype)].copy()
 
                 base_loadshapes["Ventilation"][:48] = base_loadshapes["Heating"][:48] + base_loadshapes["Cooling"][:48] + base_loadshapes["Ventilation"][:48]
-
+                base_loadshapes["Ventilation"][:48] = base_loadshapes["Ventilation"][:48]/3
                 base_loadshapes["Heating"][:48] = 0
                 base_loadshapes["Cooling"][:48] = 0
 

--- a/pipelines/rbsa/tasks/project_loadshapes.py
+++ b/pipelines/rbsa/tasks/project_loadshapes.py
@@ -62,7 +62,7 @@ class ProjectLoadshapes(t.Task):
             base_loadshapes = self.loadshapes.loc[self.loadshapes['zipcode'] == int(base)]
 
             base_loadshapes["Ventilation"][:48] = base_loadshapes["Heating"][:48] + base_loadshapes["Cooling"][:48] + base_loadshapes["Ventilation"][:48]
-
+            base_loadshapes["Ventilation"][:48] = base_loadshapes["Ventilation"][:48]/3
             base_loadshapes["Heating"][:48] = 0
             base_loadshapes["Cooling"][:48] = 0
 


### PR DESCRIPTION
### Why:
* Contains fix for lowering motor b value. This method divides the ventilation values by three during the projection step.

### What:
* The fix takes place after base cooling and heating have been added to ventilation. Motor B values get lowered significantly more than Fix 1.

### Checklist
- [ ] Finished My Changes
- [ ] Automated Unit Tests
