### PR TITLE
naming fixed with no spaces

### DIFF
--- a/pipelines/mix/mix.py
+++ b/pipelines/mix/mix.py
@@ -120,16 +120,16 @@ class MixedFeederPipeline():
         self._create_results_storage(rural_mix_hour_norm_plots_dir)
 
         logger.info('GENERATING SUBURBAN MIX PLOTS')
-        self.mix_type_plotting(mix_type=residential_mix, mix_type_name='SUBURBAN', normalization='summer total peak', directory=residential_mix_plots_dir)
+        self.mix_type_plotting(mix_type=residential_mix, mix_type_name='SUBURBAN', normalization='summer_total_peak', directory=residential_mix_plots_dir)
 
         logger.info('GENERATING URBAN MIX PLOTS')
-        self.mix_type_plotting(mix_type=commercial_mix, mix_type_name='URBAN', normalization='summer total peak', directory=commercial_mix_plots_dir)
+        self.mix_type_plotting(mix_type=commercial_mix, mix_type_name='URBAN', normalization='summer_total_peak', directory=commercial_mix_plots_dir)
 
         logger.info('GENERATING MIXED MIX PLOTS')
-        self.mix_type_plotting(mix_type=mixed_mix, mix_type_name='MIXED', normalization='summer total peak', directory=mixed_mix_plots_dir)
+        self.mix_type_plotting(mix_type=mixed_mix, mix_type_name='MIXED', normalization='summer_total_peak', directory=mixed_mix_plots_dir)
 
         logger.info('GENERATING RURAL MIX PLOTS')
-        self.mix_type_plotting(mix_type=rural_mix, mix_type_name='RURAL', normalization='summer total peak', directory=rural_mix_plots_dir)
+        self.mix_type_plotting(mix_type=rural_mix, mix_type_name='RURAL', normalization='summer_total_peak', directory=rural_mix_plots_dir)
 
         logger.info('GENERATING hour_norm SUBURBAN MIX PLOTS')
         self.mix_type_plotting(mix_type=residential_mix_hour_norm, mix_type_name='SUBURBAN', normalization='hour_norm', directory=residential_mix_hour_norm_plots_dir)

--- a/pipelines/rbsa/rbsa.py
+++ b/pipelines/rbsa/rbsa.py
@@ -228,7 +228,7 @@ class RbsaPipeline():
                 plt.ylabel('Load (pu. summer total peak)')
                 fig = plot.get_figure()
                 fig.savefig(f'{directory}/{title}.png')
-                plt.close(fig) 
+                plt.close(fig)
 
     def execute(self):
         """


### PR DESCRIPTION
### Why:
* The plot names had spaces.

### What:
* Spaces were removed from plot naming.

### Checklist
- [x] Finished My Changes
- [ ] Automated Unit Tests

